### PR TITLE
fix for dark-discord theme

### DIFF
--- a/dark-discord/styles.css
+++ b/dark-discord/styles.css
@@ -152,7 +152,7 @@ hr {
     font-size: 14px;
     line-height: 1.42857143;
     color: #eeeeee;
-    background-color: #444;
+    background-color: #444!important;
     border: 1px solid #555;
     background-image: none;
     border-radius: 4px;


### PR DESCRIPTION
- Issue was upon clicking on a field in DNS records, JS code automatically add white styling on it.
- Adding !important with the background color to overwrite the style attribute in DOM.
- This commit should fix the issue #13 